### PR TITLE
Feature/20170627 ire implicit rdd to dataframe

### DIFF
--- a/src/main/scala/net/sunshire/numspark/rdds/Conversions.scala
+++ b/src/main/scala/net/sunshire/numspark/rdds/Conversions.scala
@@ -1,0 +1,20 @@
+package net.sunshire.numspark.rdds;
+
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.SparkContext;
+import org.apache.spark.sql.{DataFrame, Row, SQLContext};
+
+object Conversions {
+  /**
+    * Implicitly convert RDD[Row] to DataFrame.
+    *
+    * @param rdd: RDD[Row]
+    * @return DataFrame
+    */
+  implicit def RDDRow2DataFrame(rdd: RDD[Row]): DataFrame = {
+    val sc = rdd.sparkContext;
+    val sqlContext = SQLContext.getOrCreate(sc);
+    val schema = rdd.first.schema;
+    return sqlContext.createDataFrame(rdd, schema);
+  }
+}

--- a/src/test/scala/net/sunshire/numspark/rdds/ConversionsSuite.scala
+++ b/src/test/scala/net/sunshire/numspark/rdds/ConversionsSuite.scala
@@ -1,0 +1,19 @@
+package net.sunshire.numspark.rdds;
+
+import com.holdenkarau.spark.testing.SharedSparkContext;
+import net.sunshire.numspark.rdds.Conversions._;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.sql.{DataFrame, Row};
+import org.scalatest.FunSuite;
+
+class ConversionsSuite extends FunSuite with SharedSparkContext {
+  test("implicit type casting(RDD[Row] -> DataFrame)") {
+    def hasImplicit(rdd: RDD[Row])
+        (implicit conversion: RDD[Row] => DataFrame = null): Boolean = {
+      return conversion != null;
+    }
+    val rdd = sc.emptyRDD[Row];
+
+    assert(hasImplicit(rdd));
+  }
+}


### PR DESCRIPTION
# Implicitly convert RDD[Row] to DataFrame

So we can manipulate RDD[Row] as a DataFrame easily.

- Adding object "net.sunshire.numspark.rdds.Conversions"
- simplify the FieldRDDOperator with DataFrame conversion
