### PR TITLE
Feature/20180126 ire isolation forest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val root = (project in file(".")).settings(
   scalaVersion := "2.11.12",
 
   sparkVersion := "2.2.0",
-  sparkComponents += "sql",
+  sparkComponents ++= Seq("mllib", "sql"),
 
   libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.0",
   libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.0" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val root = (project in file(".")).settings(
   name := "NumSpark",
-  version := "0.0.2",
+  version := "0.0.3",
 
   scalaVersion := "2.11.12",
 

--- a/src/main/scala/net/sunshire/numspark/ml/IsolationForest.scala
+++ b/src/main/scala/net/sunshire/numspark/ml/IsolationForest.scala
@@ -1,0 +1,186 @@
+package net.sunshire.numspark.ml
+
+import org.apache.spark.SparkContext
+import org.apache.spark.ml.feature.StringIndexer
+import org.apache.spark.ml.{Pipeline}
+import org.apache.spark.sql.{DataFrame, Dataset, Row, SQLContext}
+import org.apache.spark.sql.types._
+import scala.util.Random
+
+private[ml] case class IsolationTreeNode(
+    column: StructField,
+    value: Any,
+    left: Option[IsolationTreeNode],
+    right: Option[IsolationTreeNode]) extends java.io.Serializable
+
+private[ml] object IsolationTreeNode extends java.io.Serializable {
+  def pathLength(row: Row, rootOption: Option[IsolationTreeNode], depth: Int = 0): Int = {
+    if (rootOption.isEmpty) depth
+    else {
+      val root = rootOption.get
+      val column = root.column
+      column.dataType match {
+        case BooleanType =>
+          if (row.getAs[Boolean](column.name) == false) pathLength(row, root.left, depth + 1)
+          else pathLength(row, root.right, depth + 1)
+        case ByteType =>
+          if (row.getAs[Byte](column.name) <= root.value.asInstanceOf[Byte]){
+            pathLength(row, root.left, depth + 1)
+          } else pathLength(row, root.right, depth + 1)
+        // case DateType =>
+        // to-do
+        // case DecimalType =>
+        // to-do
+        case DoubleType =>
+          if (row.getAs[Double](column.name) <= root.value.asInstanceOf[Double]) {
+            pathLength(row, root.left, depth + 1)
+          } else pathLength(row, root.right, depth + 1)
+        case FloatType =>
+          if (row.getAs[Float](column.name) <= root.value.asInstanceOf[Float]) {
+            pathLength(row, root.left, depth + 1)
+          } else pathLength(row, root.right, depth + 1)
+        case IntegerType =>
+          if (row.getAs[Int](column.name) <= root.value.asInstanceOf[Int]) {
+            pathLength(row, root.left, depth + 1)
+          } else pathLength(row, root.right, depth + 1)
+        case LongType =>
+          if (row.getAs[Long](column.name) <= root.value.asInstanceOf[Long]) {
+            pathLength(row, root.left, depth + 1)
+          } else pathLength(row, root.right, depth + 1)
+        case ShortType =>
+          if (row.getAs[Short](column.name) <= root.value.asInstanceOf[Short]) {
+            pathLength(row, root.left, depth + 1)
+          } else pathLength(row, root.right, depth + 1)
+      }
+    }
+  }
+}
+
+private[ml] class IsolationTree(data: DataFrame, maxDepth: Int) {
+  private lazy val rootOption = grow(data, 0)
+
+  def fit {
+    rootOption
+  }
+
+  def transform(testset: DataFrame, topK: Int): Array[Row] = {
+    val sqlContext = testset.sqlContext
+    val rootOptionBr = sqlContext.sparkContext.broadcast(rootOption)
+    testset.rdd
+    .map(row => (IsolationTreeNode.pathLength(row, rootOptionBr.value), row))
+    .top(topK)(Ordering[Int].on(_._1))
+    .map(_._2)
+  }
+
+  private def randomChoice[T](seq: Seq[T]): Option[T] = {
+    if (seq.isEmpty) return None
+    else Option(seq(Random.nextInt(seq.length)))
+  }
+
+  private def randomPivot(
+      data: DataFrame, field: StructField, min: Any, max: Any
+  ): (Any, DataFrame, DataFrame) = {
+    val column = data.col(field.name)
+    val pivot: Any = field.dataType match {
+      case BooleanType =>
+        false
+      case ByteType =>
+        val maxByte = max.asInstanceOf[Byte]
+        val minByte = min.asInstanceOf[Byte]
+        (Random.nextInt(maxByte - minByte) + minByte).toByte
+      // case DateType =>
+      //   0 // to-do
+      // case DecimalType =>
+      //   0 // to-do
+      case DoubleType =>
+        val maxDouble = max.asInstanceOf[Double]
+        val minDouble = min.asInstanceOf[Double]
+        Random.nextDouble * (maxDouble - minDouble) + minDouble
+      case FloatType =>
+        val maxFloat = max.asInstanceOf[Float]
+        val minFloat = min.asInstanceOf[Float]
+        Random.nextFloat * (maxFloat - minFloat) + minFloat
+      case IntegerType =>
+        val maxInt = max.asInstanceOf[Int]
+        val minInt = min.asInstanceOf[Int]
+        Random.nextInt(maxInt - minInt) + minInt
+      case LongType =>
+        val maxLong = max.asInstanceOf[Long]
+        val minLong = min.asInstanceOf[Long]
+        Random.nextLong % (maxLong - minLong) + minLong
+      case ShortType =>
+        val maxShort = max.asInstanceOf[Short]
+        val minShort = min.asInstanceOf[Short]
+        (Random.nextInt(maxShort - minShort) + minShort).toShort
+      case _ => throw new Exception(field.name + " is not a numerical column.")
+    }
+    (pivot, data.filter(column <= pivot), data.filter(column > pivot))
+  }
+
+  private def grow(data: DataFrame, depth: Int): Option[IsolationTreeNode] = {
+    if (depth >= maxDepth) return None
+    val columns = columnAndBoundary(data).filter{case (column, min, max) => min != max}
+    val choosedColumn = randomChoice(columns)
+    if (choosedColumn.isEmpty) return None
+    val (column, min, max) = choosedColumn.get
+    val pivot = randomPivot(data, column, min, max)
+    val filteredColumns = columns.map(field => data.col(field._1.name))
+    return Option(IsolationTreeNode(
+      column,
+      pivot._1,
+      grow(pivot._2.select(filteredColumns: _*), depth + 1),
+      grow(pivot._3.select(filteredColumns: _*), depth + 1)
+    ))
+  }
+
+  def columnAndBoundary(data: DataFrame): Seq[(StructField, Any, Any)] = {
+    val columns = data.schema.toList
+    val minmaxColumns = columns.map{ _column =>
+      import org.apache.spark.sql.functions._
+      val name = _column.name
+      List(min(name).as(name + "Min"), max(name).as(name + "Max"))
+    }.flatten
+    val row = data.select(minmaxColumns: _*).first
+    (for (column <- columns) yield {
+      column.dataType match {
+        case BooleanType =>
+          (column,
+            row.getAs[Boolean](column.name + "Min"),
+            row.getAs[Boolean](column.name + "Max"))
+        case ByteType =>
+          (column,
+            row.getAs[Byte](column.name + "Min"),
+            row.getAs[Byte](column.name + "Max"))
+        // case DateType =>
+        //   (column,
+        //     row.getAs[java.sql.Date](column.name + "Min"),
+        //     row.getAs[java.sql.Date](column.name + "Max"))
+        // case DecimalType =>
+        //   (column,
+        //     row.getAs[Decimal](column.name + "Min"),
+        //     row.getAs[Decimal](column.name + "Max"))
+        case DoubleType =>
+          (column,
+            row.getAs[Double](column.name + "Min"),
+            row.getAs[Double](column.name + "Max"))
+        case FloatType =>
+          (column,
+            row.getAs[Float](column.name + "Min"),
+            row.getAs[Float](column.name + "Max"))
+        case IntegerType =>
+          (column,
+            row.getAs[Int](column.name + "Min"),
+            row.getAs[Int](column.name + "Max"))
+        case LongType =>
+          (column,
+            row.getAs[Long](column.name + "Min"),
+            row.getAs[Long](column.name + "Max"))
+        case ShortType =>
+          (column,
+            row.getAs[Short](column.name + "Min"),
+            row.getAs[Short](column.name + "Max"))
+        case _ => throw new Exception(column.name + " is not a numerical column.")
+      }
+    })
+  }
+}

--- a/src/main/scala/net/sunshire/numspark/ml/IsolationForest.scala
+++ b/src/main/scala/net/sunshire/numspark/ml/IsolationForest.scala
@@ -372,13 +372,13 @@ object IsolationTree {
     (for (column <- columns) yield {
       column.dataType match {
         case BooleanType =>
-          (column,
+          Option((column,
             row.getAs[Boolean](column.name + "Min"),
-            row.getAs[Boolean](column.name + "Max"))
+            row.getAs[Boolean](column.name + "Max")))
         case ByteType =>
-          (column,
+          Option((column,
             row.getAs[Byte](column.name + "Min"),
-            row.getAs[Byte](column.name + "Max"))
+            row.getAs[Byte](column.name + "Max")))
         // case DateType =>
         //   (column,
         //     row.getAs[java.sql.Date](column.name + "Min"),
@@ -388,28 +388,28 @@ object IsolationTree {
         //     row.getAs[Decimal](column.name + "Min"),
         //     row.getAs[Decimal](column.name + "Max"))
         case DoubleType =>
-          (column,
+          Option((column,
             row.getAs[Double](column.name + "Min"),
-            row.getAs[Double](column.name + "Max"))
+            row.getAs[Double](column.name + "Max")))
         case FloatType =>
-          (column,
+          Option((column,
             row.getAs[Float](column.name + "Min"),
-            row.getAs[Float](column.name + "Max"))
+            row.getAs[Float](column.name + "Max")))
         case IntegerType =>
-          (column,
+          Option((column,
             row.getAs[Int](column.name + "Min"),
-            row.getAs[Int](column.name + "Max"))
+            row.getAs[Int](column.name + "Max")))
         case LongType =>
-          (column,
+          Option((column,
             row.getAs[Long](column.name + "Min"),
-            row.getAs[Long](column.name + "Max"))
+            row.getAs[Long](column.name + "Max")))
         case ShortType =>
-          (column,
+          Option((column,
             row.getAs[Short](column.name + "Min"),
-            row.getAs[Short](column.name + "Max"))
-        case _ => throw new Exception(column.name + " is not a numerical column.")
+            row.getAs[Short](column.name + "Max")))
+        case _ => None
       }
-    })
+    }).flatten
   }
 
   /**

--- a/src/main/scala/net/sunshire/numspark/ml/IsolationForest.scala
+++ b/src/main/scala/net/sunshire/numspark/ml/IsolationForest.scala
@@ -56,7 +56,7 @@ private[ml] object IsolationTreeNode extends java.io.Serializable {
   }
 }
 
-private[ml] class IsolationTree(data: DataFrame, maxDepth: Int) {
+class IsolationTree(data: DataFrame, maxDepth: Int) {
   private lazy val rootOption = grow(data, 0)
 
   def fit {

--- a/src/main/scala/net/sunshire/numspark/ml/IsolationForest.scala
+++ b/src/main/scala/net/sunshire/numspark/ml/IsolationForest.scala
@@ -152,7 +152,19 @@ class IsolationForestModel(trees: Seq[IsolationTreeModel]) {
     ).as("anomalyScore")
     testset.select((allColumns ++ pathLengthColumns): _*)
     .select((allColumns :+ anomalyScore): _*)
-    .orderBy(anomalyScore.desc)
+  }
+
+  /**
+    * Predict a the anomaly by given threshold.
+    *
+    * @param testset: the dataset to be predicted
+    * @param threshold: the threshold to be predict, which should between 0 and 1.
+    * @return the origin dataframe with a new column "isOulier"
+    */
+  def predict(testset: DataFrame, threshold: Double = 0.6): DataFrame = {
+    import org.apache.spark.sql.functions._
+    transform(testset).withColumn("isOutlier", col("anomalyScore") >= lit(threshold))
+    .drop("anomalyScore")
   }
 
   /**

--- a/src/main/scala/net/sunshire/numspark/utils/ExtendedRandom.scala
+++ b/src/main/scala/net/sunshire/numspark/utils/ExtendedRandom.scala
@@ -1,0 +1,25 @@
+package net.sunshire.numspark.utils
+
+import scala.util.Random
+
+object ExtendedRandom {
+  def apply(delegation: Random) = new ExtendedRandom(delegation)
+
+  /**
+    * To implicitly convert Random to ExtendedRandom for some extended methods.
+    */
+  implicit def entend(delegation: Random) = ExtendedRandom(delegation)
+}
+
+class ExtendedRandom(delegation: Random) {
+  /**
+    * Choose from a Seq randomly.
+    *
+    * @param seq: Seq[T]; the sequence to be choose.
+    * @return Option[T]; the chosen element, could be None when the sequence has no element.
+    */
+  def choice[T](seq: Seq[T]): Option[T] = {
+    if (seq.isEmpty) return None
+    else Option(seq(delegation.nextInt(seq.length)))
+  }
+}

--- a/src/test/scala/net/sunshire/numspark/ml/IsolationForestSuite.scala
+++ b/src/test/scala/net/sunshire/numspark/ml/IsolationForestSuite.scala
@@ -219,8 +219,8 @@ class IsolationForestSuite extends FunSuite with BeforeAndAfter with SharedSpark
       sc.parallelize(normalSeq ++ abnormalSeq), anomalySchema)
     val forest = new IsolationForest(anomalyData, 5, 10)
     val model = forest.fit
-    model.write(modelPath)
-    val readModel = IsolationForest.readModel(modelPath)
-    val anomalies = readModel.transform(anomalyData)
+    model.save(sc, modelPath)
+    val loaded = IsolationForest.load(sc, modelPath)
+    val anomalies = loaded.transform(anomalyData)
   }
 }

--- a/src/test/scala/net/sunshire/numspark/ml/IsolationForestSuite.scala
+++ b/src/test/scala/net/sunshire/numspark/ml/IsolationForestSuite.scala
@@ -1,0 +1,120 @@
+package net.sunshire.numspark.ml
+
+import com.holdenkarau.spark.testing.SharedSparkContext
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.apache.spark.sql.types._
+import org.scalatest.{BeforeAndAfter, FunSuite}
+import scala.math
+
+class IsolationForestSuite extends FunSuite with BeforeAndAfter with SharedSparkContext {
+  var sqlContext: SQLContext = _
+  var schema: StructType = _
+  var data: DataFrame = _
+  before {
+    sqlContext = new SQLContext(sc)
+    schema = StructType(Seq(
+      StructField("bool", BooleanType),
+      StructField("byte", ByteType),
+      StructField("double", DoubleType),
+      StructField("float", FloatType),
+      StructField("int", IntegerType),
+      StructField("long", LongType),
+      StructField("short", ShortType)
+    ))
+    data = sqlContext.createDataFrame(sc.parallelize(Seq(
+      Row(false, 1.toByte, 1.0, (1.0).toFloat, 1, 1.toLong, 1.toShort),
+      Row(true, 2.toByte, 2.0, (2.0).toFloat, 2, 2.toLong, 2.toShort)
+    )), schema)
+  }
+
+  test("IsolationTree.columnAndBoundary") {
+    val expected = Map(
+      "bool" -> (false, true),
+      "byte" -> (1.toByte, 2.toByte),
+      "double" -> (1.0, 2.0),
+      "float" -> ((1.0).toFloat, (2.0).toFloat),
+      "int" -> (1, 2),
+      "long" -> (1.toLong, 2.toLong),
+      "short" -> (1.toShort, 2.toShort)
+    )
+    val results: Seq[(StructField, Any, Any)] = IsolationTree.columnAndBoundary(data)
+    for (result <- results) {
+      assert(result._2 == expected(result._1.name)._1)
+      assert(result._3 == expected(result._1.name)._2)
+    }
+  }
+
+  test("IsolationTree.randomPivot") {
+    import org.apache.spark.sql.functions
+    val expectedRange = Map(
+      "bool" -> (false, true),
+      "byte" -> (1.toByte, 2.toByte),
+      "double" -> (1.0, 2.0),
+      "float" -> ((1.0).toFloat, (2.0).toFloat),
+      "int" -> (1, 2),
+      "long" -> (1.toLong, 2.toLong),
+      "short" -> (1.toShort, 2.toShort)
+    )
+    val schema = data.schema
+    for ((name, values) <- expectedRange) {
+      val column = schema.apply(name)
+      val (pivot, left, right): (Any, DataFrame, DataFrame) = IsolationTree.randomPivot(
+        data, column, values._1, values._2)
+      val min = left.select(functions.max(left.col(name))).first.apply(0)
+      val max = right.select(functions.min(right.col(name))).first.apply(0)
+      column.dataType match {
+        case BooleanType =>
+          assert(pivot.asInstanceOf[Boolean] == false)
+          assert(min.asInstanceOf[Boolean] == false)
+          assert(max.asInstanceOf[Boolean] == true)
+        case ByteType =>
+          assert(values._1.asInstanceOf[Byte] <= pivot.asInstanceOf[Byte] &&
+            pivot.asInstanceOf[Byte] < values._2.asInstanceOf[Byte])
+          assert(values._1.asInstanceOf[Byte] <= min.asInstanceOf[Byte] &&
+            min.asInstanceOf[Byte] <= pivot.asInstanceOf[Byte])
+          assert(pivot.asInstanceOf[Byte] < max.asInstanceOf[Byte] &&
+            max.asInstanceOf[Byte] <= values._2.asInstanceOf[Byte])
+        // case DateType =>
+        // to-do
+        // case DecimalType =>
+        // to-do
+        case DoubleType =>
+          assert(values._1.asInstanceOf[Double] <= pivot.asInstanceOf[Double] &&
+            pivot.asInstanceOf[Double] < values._2.asInstanceOf[Double])
+          assert(values._1.asInstanceOf[Double] <= min.asInstanceOf[Double] &&
+            min.asInstanceOf[Double] <= pivot.asInstanceOf[Double])
+          assert(pivot.asInstanceOf[Double] < max.asInstanceOf[Double] &&
+            max.asInstanceOf[Double] <= values._2.asInstanceOf[Double])
+        case FloatType =>
+          assert(values._1.asInstanceOf[Float] <= pivot.asInstanceOf[Float] &&
+            pivot.asInstanceOf[Float] < values._2.asInstanceOf[Float])
+          assert(values._1.asInstanceOf[Float] <= min.asInstanceOf[Float] &&
+            min.asInstanceOf[Float] <= pivot.asInstanceOf[Float])
+          assert(pivot.asInstanceOf[Float] < max.asInstanceOf[Float] &&
+            max.asInstanceOf[Float] <= values._2.asInstanceOf[Float])
+        case IntegerType =>
+          assert(values._1.asInstanceOf[Integer] <= pivot.asInstanceOf[Integer] &&
+            pivot.asInstanceOf[Integer] < values._2.asInstanceOf[Integer])
+          assert(values._1.asInstanceOf[Integer] <= min.asInstanceOf[Integer] &&
+            min.asInstanceOf[Integer] <= pivot.asInstanceOf[Integer])
+          assert(pivot.asInstanceOf[Integer] < max.asInstanceOf[Integer] &&
+            max.asInstanceOf[Integer] <= values._2.asInstanceOf[Integer])
+        case LongType =>
+          assert(values._1.asInstanceOf[Long] <= pivot.asInstanceOf[Long] &&
+            pivot.asInstanceOf[Long] < values._2.asInstanceOf[Long])
+          assert(values._1.asInstanceOf[Long] <= min.asInstanceOf[Long] &&
+            min.asInstanceOf[Long] <= pivot.asInstanceOf[Long])
+          assert(pivot.asInstanceOf[Long] < max.asInstanceOf[Long] &&
+            max.asInstanceOf[Long] <= values._2.asInstanceOf[Long])
+        case ShortType =>
+          assert(values._1.asInstanceOf[Short] <= pivot.asInstanceOf[Short] &&
+            pivot.asInstanceOf[Short] < values._2.asInstanceOf[Short])
+          assert(values._1.asInstanceOf[Short] <= min.asInstanceOf[Short] &&
+            min.asInstanceOf[Short] <= pivot.asInstanceOf[Short])
+          assert(pivot.asInstanceOf[Short] < max.asInstanceOf[Short] &&
+            max.asInstanceOf[Short] <= values._2.asInstanceOf[Short])
+      }
+    }
+  }
+}

--- a/src/test/scala/net/sunshire/numspark/ml/IsolationForestSuite.scala
+++ b/src/test/scala/net/sunshire/numspark/ml/IsolationForestSuite.scala
@@ -42,6 +42,7 @@ class IsolationForestSuite extends FunSuite with BeforeAndAfter with SharedSpark
   before {
     sqlContext = new SQLContext(sc)
     schema = StructType(Seq(
+      StructField("id", StringType),
       StructField("bool", BooleanType),
       StructField("byte", ByteType),
       StructField("double", DoubleType),
@@ -51,8 +52,8 @@ class IsolationForestSuite extends FunSuite with BeforeAndAfter with SharedSpark
       StructField("short", ShortType)
     ))
     data = sqlContext.createDataFrame(sc.parallelize(Seq(
-      Row(false, 1.toByte, 1.0, (1.0).toFloat, 1, 1.toLong, 1.toShort),
-      Row(true, 2.toByte, 2.0, (2.0).toFloat, 2, 2.toLong, 2.toShort)
+      Row("A", false, 1.toByte, 1.0, (1.0).toFloat, 1, 1.toLong, 1.toShort),
+      Row("B", true, 2.toByte, 2.0, (2.0).toFloat, 2, 2.toLong, 2.toShort)
     )), schema)
   }
 
@@ -91,7 +92,6 @@ class IsolationForestSuite extends FunSuite with BeforeAndAfter with SharedSpark
       "long" -> (1.toLong, 2.toLong),
       "short" -> (1.toShort, 2.toShort)
     )
-    val schema = data.schema
     for ((name, values) <- expectedRange) {
       val column = schema.apply(name)
       val (pivot, left, right): (Any, DataFrame, DataFrame) = IsolationTree.randomPivot(

--- a/src/test/scala/net/sunshire/numspark/ml/IsolationForestSuite.scala
+++ b/src/test/scala/net/sunshire/numspark/ml/IsolationForestSuite.scala
@@ -11,7 +11,7 @@ class IsolationForestSuite extends FunSuite with BeforeAndAfter with SharedSpark
   var sqlContext: SQLContext = _
   var schema: StructType = _
   var data: DataFrame = _
-  val modelPath = "/tmp/model"
+  val modelPath = "/tmp/numspark/model"
   val normalSeq = Seq(
     Row(0.0, 1),
     Row(0.0, 2),
@@ -57,9 +57,10 @@ class IsolationForestSuite extends FunSuite with BeforeAndAfter with SharedSpark
   }
 
   after {
-    import java.io._
+    import java.io.File
+    import org.apache.commons.io.FileUtils
     val modelFilePointer = new File(modelPath)
-    modelFilePointer.delete
+    FileUtils.deleteDirectory(modelFilePointer)
   }
 
   test("IsolationTree.columnAndBoundary") {
@@ -208,9 +209,9 @@ class IsolationForestSuite extends FunSuite with BeforeAndAfter with SharedSpark
       sc.parallelize(normalSeq ++ abnormalSeq), anomalySchema)
     val tree = new IsolationTree(anomalyData, 2)
     val model = tree.fit
-    model.write(modelPath)
-    val readModel = IsolationTree.readModel(modelPath)
-    val anomalies = readModel.transform(anomalyData)
+    model.save(sc, modelPath)
+    val loaded = IsolationTree.load(sc, modelPath)
+    val anomalies = loaded.transform(anomalyData)
   }
 
   test("write/read forest model") {

--- a/src/test/scala/net/sunshire/numspark/ml/IsolationForestSuite.scala
+++ b/src/test/scala/net/sunshire/numspark/ml/IsolationForestSuite.scala
@@ -181,7 +181,7 @@ class IsolationForestSuite extends FunSuite with BeforeAndAfter with SharedSpark
 
   test("predict") {
     val iterationNumber = 10
-    val expectedRate = 0.8
+    val expectedRate = 0.6
     val anomalyData = sqlContext.createDataFrame(
       sc.parallelize(normalSeq ++ abnormalSeq), anomalySchema)
     var scoringBoard = Array.fill[Int](abnormalSeq.length)(0)

--- a/src/test/scala/net/sunshire/numspark/utils/ExtendedRandomSuite.scala
+++ b/src/test/scala/net/sunshire/numspark/utils/ExtendedRandomSuite.scala
@@ -24,6 +24,6 @@ class EntendedRandomSuite extends FunSuite {
   test("choice from empty set") {
     val sequence = Seq[Int]()
     val choiceOption = Random.choice(sequence)
-    assert(choice.isEmpty)
+    assert(choiceOption.isEmpty)
   }
 }

--- a/src/test/scala/net/sunshire/numspark/utils/ExtendedRandomSuite.scala
+++ b/src/test/scala/net/sunshire/numspark/utils/ExtendedRandomSuite.scala
@@ -1,0 +1,29 @@
+package net.sunshire.numspark.utils
+
+import org.scalatest.FunSuite
+import net.sunshire.numspark.utils.ExtendedRandom._
+import scala.util.Random
+
+class EntendedRandomSuite extends FunSuite {
+  test("able to type cast from Random to ExtendedRandom") {
+    def hasImplicit(random: Random)
+    (implicit conversion: Random => ExtendedRandom = null): Boolean = conversion != null
+
+    assert(hasImplicit(Random))
+  }
+
+  test("random choice") {
+    val lowerBound = 1
+    val upperBound = 10
+    val sequence = lowerBound to upperBound
+    val choice = Random.choice(sequence).get
+    assert(choice >= lowerBound)
+    assert(choice <= upperBound)
+  }
+
+  test("choice from empty set") {
+    val sequence = Seq[Int]()
+    val choiceOption = Random.choice(sequence)
+    assert(choice.isEmpty)
+  }
+}


### PR DESCRIPTION
# Isolation Forest [REF](https://cs.nju.edu.cn/zhouzh/zhouzh.files/publication/icdm08b.pdf)

## Usage
refer to `src/test/scala/net/sunshire/numspark/ml/IsolationForestSuite.scala`

## Development
1. Extended Random (to extend Scala random library)  
2. Isolation Tree/Forest

### Detail
* `IsolationTree` is implemented with `IsolationTreeNode`  
* `IsolationForest` is implemented with `IsolationTree`  
* For tree/forest model storage, transform the `IsolationTreeNode` to `IsolationTreeNodeData`

## Notice
* Since the model is based on randomness, the test case is implemented on statistical result. Which may not pass the benchmark occasionally.